### PR TITLE
Feature/sitewide component properties

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/PageRootProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/PageRootProvider.java
@@ -1,11 +1,18 @@
 package com.adobe.acs.commons.wcm;
 
+import aQute.bnd.annotation.ConsumerType;
 import com.day.cq.wcm.api.Page;
 import org.apache.sling.api.resource.Resource;
 
 /**
  * Service to fetch the site root page (i.e. home page) for a given resource.
  */
+@ConsumerType
 public interface PageRootProvider {
+    /**
+     * Returns the root page for the provided resource. The root page is selected via the regex provided in the PageRootProviderImpl's OSGi configuration.
+     * @param resource
+     * @return
+     */
     Page getRootPage(Resource resource);
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderImpl.java
@@ -1,67 +1,113 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.wcm.impl;
 
 import com.adobe.acs.commons.wcm.PageRootProvider;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.commons.osgi.PropertiesUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Component(
-    label = "ACS AEM Commons - Page Root Provider",
-    description = "Service to fetch the site root page (i.e. home page) for a given resource.",
-    policy = ConfigurationPolicy.REQUIRE,
-    metatype = true
+        label = "ACS AEM Commons - Page Root Provider",
+        description = "Service to fetch the site root page (i.e. home page) for a given resource.",
+        policy = ConfigurationPolicy.REQUIRE,
+        metatype = true
 )
 @Service
 public class PageRootProviderImpl implements PageRootProvider {
-    private static final Logger log = LoggerFactory.getLogger(PageRootProviderImpl.class.getName());
-    private static final String DEFAULT_PAGE_ROOT_PATH = "/content/";
+    private static final Logger log = LoggerFactory.getLogger(PageRootProviderImpl.class);
+    private static final String DEFAULT_PAGE_ROOT_PATH = "/content";
 
-    @Property(label = "page root path", description = "Page root path (allows regex pattern)",
-            value = DEFAULT_PAGE_ROOT_PATH)
+    @Property(
+            label = "Root page path pattern",
+            description = "Regex(es) used to select the root page root path. Evaluates list top-down; first match wins. Defaults to [ " + DEFAULT_PAGE_ROOT_PATH + " ]",
+            cardinality = Integer.MAX_VALUE,
+            value = { DEFAULT_PAGE_ROOT_PATH })
     private static final String PAGE_ROOT_PATH = "page.root.path";
 
-    private Pattern pageRootPattern = null;
-
-    @Activate
-    protected void activate(Map<String, Object> props) {
-        String pageRootPath = PropertiesUtil.toString(props.get(PAGE_ROOT_PATH), DEFAULT_PAGE_ROOT_PATH);
-        pageRootPattern = Pattern.compile("^(" + pageRootPath + ")(|/.+)$");
-    }
+    private List<Pattern> pageRootPatterns = new ArrayList<Pattern>();
 
     @Override
     public Page getRootPage(Resource resource) {
-        String resourcePath = resource.getPath();
-        Matcher matcher = pageRootPattern.matcher(resourcePath);
-        if (matcher.matches()) {
-            ResourceResolver resolver = resource.getResourceResolver();
-            PageManager pageManager = resolver.adaptTo(PageManager.class);
-            String pagePath = matcher.group(1);
+        String pagePath = getRootPagePath(resource.getPath());
 
+        if (pagePath != null) {
+            PageManager pageManager = resource.getResourceResolver().adaptTo(PageManager.class);
             Page rootPage = pageManager.getPage(pagePath);
+
             if (rootPage == null) {
-                log.debug("Page not found at {}", pagePath);
+                log.debug("Page Root not found at [ {} ]", pagePath);
             } else if (!rootPage.isValid()) {
-                log.debug("Page invalid at {}", pagePath);
+                log.debug("Page Root invalid at [ {} ]", pagePath);
             } else {
-                log.debug("Page root found at {}", pagePath);
+                log.debug("Page Root found at [ {} ]", pagePath);
                 return rootPage;
             }
-        } else {
-            log.debug("Resource path does not include the configured page root path");
         }
+
+        log.debug("Resource path does not include the configured page root path.");
         return null;
+    }
+
+    protected String getRootPagePath(String resourcePath) {
+        for (Pattern pattern : pageRootPatterns) {
+            final Matcher matcher = pattern.matcher(resourcePath);
+
+            if (matcher.find()) {
+                String tmp = StringUtils.trim(matcher.group(1));
+                tmp = org.apache.commons.lang.StringUtils.removeEnd(tmp, "/");
+                return tmp;
+            }
+        }
+
+        return null;
+    }
+
+    @Activate
+    protected void activate(Map<String, Object> props) {
+        pageRootPatterns = new ArrayList<Pattern>();
+        String[] regexes = PropertiesUtil.toStringArray(props.get(PAGE_ROOT_PATH), new String[] { DEFAULT_PAGE_ROOT_PATH });
+
+        for(String regex : regexes) {
+            try {
+                Pattern p = Pattern.compile("^(" + regex + ")");
+                pageRootPatterns.add(p);
+                log.debug("Added Page Root Pattern [ {} ] to PageRootProvider", p.toString());
+            } catch (Exception e) {
+                log.error("Could not compile regex [ {} ] to pattern. Skipping...", regex, e);
+            }
+        }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
@@ -1,0 +1,13 @@
+package com.adobe.acs.commons.wcm.properties.shared;
+
+import aQute.bnd.annotation.ProviderType;
+
+@ProviderType
+public interface SharedComponentProperties {
+    String SHARED_PROPERTIES = "sharedProperties";
+    String GLOBAL_PROPERTIES = "globalProperties";
+    String MERGED_PROPERTIES = "mergedProperties";
+
+    String NN_GLOBAL_COMPONENT_PROPERTIES = "global-component-properties";
+    String NN_SHARED_COMPONENT_PROPERTIES = "shared-component-properties";
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProvider.java
@@ -1,6 +1,26 @@
-package com.adobe.acs.commons.wcm.impl;
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wcm.properties.shared.impl;
 
 import com.adobe.acs.commons.wcm.PageRootProvider;
+import com.adobe.acs.commons.wcm.properties.shared.SharedComponentProperties;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.commons.WCMUtils;
@@ -8,6 +28,7 @@ import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.scripting.api.BindingsValuesProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,29 +40,28 @@ import java.util.Map;
 /**
  * Bindings Values Provider that adds bindings for globalProperties,
  * sharedProperties, and mergedProperties maps.
- *
+ * <p>
  * globalProperties contains the shared properties accessible by
  * all components.
- *
+ * <p>
  * sharedProperties contains the shared properties specific to the
  * current component.
- *
+ * <p>
  * mergedProperties is a merge of the instance-level, shared, and
  * global properties for the current component, giving preference
  * to instance-level values, then shared values, and finally global
  * values when properties exist at multiple levels with the same name.
  */
-@org.apache.felix.scr.annotations.Component(
-    label = "ACS AEM Commons - Shared Component Properties Provider",
-    description = "Adds bindings for 'globalProperties', 'sharedProperties', and 'mergedProperties'."
-)
+@org.apache.felix.scr.annotations.Component
 @Service
 public class SharedComponentPropertiesBindingsValuesProvider implements BindingsValuesProvider {
-
     private static final Logger log = LoggerFactory.getLogger(SharedComponentPropertiesBindingsValuesProvider.class);
 
     @Reference
     private PageRootProvider pageRootProvider;
+
+    @Reference
+    private SharedComponentProperties sharedComponentProperties;
 
     @Override
     public void addBindings(Bindings bindings) {
@@ -60,17 +80,17 @@ public class SharedComponentPropertiesBindingsValuesProvider implements Bindings
     private void setSharedProperties(Bindings bindings, Resource resource, Component component) {
         Page pageRoot = pageRootProvider.getRootPage(resource);
         if (pageRoot != null) {
-            String globalPropsPath = pageRoot.getPath() + "/jcr:content/global-component-properties";
+            String globalPropsPath = pageRoot.getPath() + "/jcr:content/" + SharedComponentProperties.NN_GLOBAL_COMPONENT_PROPERTIES;
             Resource globalPropsResource = resource.getResourceResolver().getResource(globalPropsPath);
             if (globalPropsResource != null) {
-                bindings.put("globalProperties", globalPropsResource.getValueMap());
+                bindings.put(SharedComponentProperties.GLOBAL_PROPERTIES, globalPropsResource.getValueMap());
             }
 
-            String sharedPropsPath = pageRoot.getPath() + "/jcr:content/shared-component-properties/"
+            String sharedPropsPath = pageRoot.getPath() + "/jcr:content/" + SharedComponentProperties.NN_SHARED_COMPONENT_PROPERTIES +  "/"
                     + component.getResourceType();
             Resource sharedPropsResource = resource.getResourceResolver().getResource(sharedPropsPath);
             if (sharedPropsResource != null) {
-                bindings.put("sharedProperties", sharedPropsResource.getValueMap());
+                bindings.put(SharedComponentProperties.SHARED_PROPERTIES, sharedPropsResource.getValueMap());
             }
         } else {
             log.debug("Could not determine shared properties root for resource {}", resource.getPath());
@@ -78,14 +98,14 @@ public class SharedComponentPropertiesBindingsValuesProvider implements Bindings
     }
 
     private void setMergedProperties(Bindings bindings, Resource resource) {
-        ValueMap globalPropertyMap = (ValueMap) bindings.get("globalProperties");
-        ValueMap sharedPropertyMap = (ValueMap) bindings.get("sharedProperties");
+        ValueMap globalPropertyMap = (ValueMap) bindings.get(SharedComponentProperties.GLOBAL_PROPERTIES);
+        ValueMap sharedPropertyMap = (ValueMap) bindings.get(SharedComponentProperties.SHARED_PROPERTIES);
         ValueMap localPropertyMap = resource.getValueMap();
 
-        bindings.put("mergedProperties", mergeProperties(localPropertyMap, sharedPropertyMap, globalPropertyMap));
+        bindings.put(SharedComponentProperties.MERGED_PROPERTIES, mergeProperties(localPropertyMap, sharedPropertyMap, globalPropertyMap));
     }
 
-    private Map<String, Object> mergeProperties(ValueMap instanceProperties, ValueMap sharedProperties, ValueMap globalProperties) {
+    private ValueMap mergeProperties(ValueMap instanceProperties, ValueMap sharedProperties, ValueMap globalProperties) {
         Map<String, Object> mergedProperties = new HashMap<String, Object>();
 
         // Add Component Global Configs
@@ -103,6 +123,6 @@ public class SharedComponentPropertiesBindingsValuesProvider implements Bindings
             mergedProperties.putAll(instanceProperties);
         }
 
-        return mergedProperties;
+        return new ValueMapDecorator(mergedProperties);
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesImpl.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wcm.properties.shared.impl;
+
+import com.adobe.acs.commons.wcm.properties.shared.SharedComponentProperties;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.ConfigurationPolicy;
+import org.apache.felix.scr.annotations.Service;
+
+@Component(
+        label = "ACS AEM Commons - Shared Component Properties",
+        description = "Create an OSGi configuration to enable Shared Component Properties",
+        policy = ConfigurationPolicy.REQUIRE,
+        metatype = true
+)
+@Service
+public class SharedComponentPropertiesImpl implements SharedComponentProperties {
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesPageInfoProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesPageInfoProvider.java
@@ -17,12 +17,12 @@
  * limitations under the License.
  * #L%
  */
-package com.adobe.acs.commons.wcm.impl;
+package com.adobe.acs.commons.wcm.properties.shared.impl;
 
 import com.adobe.acs.commons.wcm.PageRootProvider;
+import com.adobe.acs.commons.wcm.properties.shared.SharedComponentProperties;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageInfoProvider;
-import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -43,13 +43,16 @@ import javax.jcr.security.Privilege;
  * are enabled.  Note that this provider requires Page Root Provider to
  * be configured.
  */
-@Component
+@org.apache.felix.scr.annotations.Component
 @Service
-public class SharedComponentPropsPageInfoProvider implements PageInfoProvider {
-    private static final Logger log = LoggerFactory.getLogger(SharedComponentPropsPageInfoProvider.class);
+public class SharedComponentPropertiesPageInfoProvider implements PageInfoProvider {
+    private static final Logger log = LoggerFactory.getLogger(SharedComponentPropertiesPageInfoProvider.class);
 
     @Reference
     private PageRootProvider pageRootProvider;
+
+    @Reference
+    private SharedComponentProperties sharedComponentProperties;
 
     @Override
     public void updatePageInfo(SlingHttpServletRequest request, JSONObject info, Resource resource)
@@ -72,8 +75,8 @@ public class SharedComponentPropsPageInfoProvider implements PageInfoProvider {
                         props.put("enabled", true);
                         props.put("root", page.getPath());
                     }
-                } catch (RepositoryException re) {
-                    log.error("Unexpected error checking permissions to modify shared component properties", re);
+                } catch (RepositoryException e) {
+                    log.error("Unexpected error checking permissions to modify shared component properties", e);
                 }
             }
         } else {
@@ -81,5 +84,4 @@ public class SharedComponentPropsPageInfoProvider implements PageInfoProvider {
         }
         info.put("sharedComponentProperties", props);
     }
-
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Shared Component Properties.
+ */
+@aQute.bnd.annotation.Version("1.0.0")
+package com.adobe.acs.commons.wcm.properties.shared;

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/tags/DefineObjects.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/tags/DefineObjects.java
@@ -12,7 +12,7 @@ import javax.servlet.jsp.tagext.BodyTagSupport;
  * component instance-level properties to the pageContext of a JSP,
  * but it instead adds globalProperties, sharedProperties, and
  * mergedProperties maps that come from
- * com.adobe.acs.commons.wcm.impl.SharedComponentPropertiesBindingsValuesProvider
+ * com.adobe.acs.commons.wcm.properties.shared.impl.SharedComponentPropertiesBindingsValuesProvider
  */
 @ProviderType
 @Tag(bodyContentType = BodyContentType.JSP, value = "defineObjects")

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderImplTest.java
@@ -1,0 +1,60 @@
+package com.adobe.acs.commons.wcm.impl;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class PageRootProviderImplTest {
+    PageRootProviderImpl provider = new PageRootProviderImpl();
+
+    Map<String, Object> config = new HashMap<String, Object>();
+
+    @Test
+    public void getRootPagePath() throws Exception {
+        config.put("page.root.path", new String[]{"/content/"});
+        provider.activate(config);
+
+        assertEquals("/content", provider.getRootPagePath("/content/site/en_us/products/product-x"));
+        assertEquals("/content", provider.getRootPagePath("/content/site/en_us/products/product-x/jcr:content/my-component"));
+        assertEquals("/content", provider.getRootPagePath("/content/site/en_us"));
+        assertEquals("/content", provider.getRootPagePath("/content/"));
+
+        assertNull("/content", provider.getRootPagePath("/content"));
+        assertNull("/content", provider.getRootPagePath("/etc/site"));
+        assertNull("/content", provider.getRootPagePath("/conf/site"));
+    }
+
+    @Test
+    public void getRootPagePath_Regex() throws Exception {
+        config.put("page.root.path", new String[]{"/content/site/([a-z_-]+)"});
+        provider.activate(config);
+
+        assertEquals("/content/site/en_us", provider.getRootPagePath("/content/site/en_us/products/product-x"));
+        assertEquals("/content/site/fr", provider.getRootPagePath("/content/site/fr/products/product-x/jcr:content/my-component"));
+        assertEquals("/content/site/de_de", provider.getRootPagePath("/content/site/de_de"));
+
+        assertNull(provider.getRootPagePath("/content"));
+        assertNull(provider.getRootPagePath("/content/en_us/products"));
+        assertNull(provider.getRootPagePath("/content/123/site"));
+    }
+
+    @Test
+    public void getRootPagePath_Order1() throws Exception {
+        config.put("page.root.path", new String[]{"/content", "/content/a"});
+        provider.activate(config);
+
+        assertEquals("/content", provider.getRootPagePath("/content/a/b/c"));
+    }
+
+    @Test
+    public void getRootPagePath_Order2() throws Exception {
+        config.put("page.root.path", new String[]{"/content/a", "/content"});
+        provider.activate(config);
+
+        assertEquals("/content/a", provider.getRootPagePath("/content/a/b/c"));
+        assertEquals("/content", provider.getRootPagePath("/content/b"));
+    }
+}

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/classicui/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/classicui/.content.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-      jcr:primaryType="cq:ClientLibraryFolder"
-      categories="[cq.widgets]"/>
+          jcr:primaryType="cq:ClientLibraryFolder"
+          categories="[acs-commons.shared-component-properties.classic]"/>
+        <!-- Embed in cq.widgets -->

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/classicui/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/classicui/js.txt
@@ -1,1 +1,2 @@
+#base=js
 shared-component-properties-classic.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/classicui/js/shared-component-properties-classic.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/classicui/js/shared-component-properties-classic.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 (function() {
     CQ.wcm.EditBase.EDITSHARED = "EDITSHARED";
     CQ.wcm.EditBase.EDITGLOBAL = "EDITGLOBAL";

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/.content.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-      jcr:primaryType="cq:ClientLibraryFolder"
-      categories="[cq.authoring.editor]"/>
+          jcr:primaryType="cq:ClientLibraryFolder"
+          categories="[acs-commons.shared-component-properties]"/>
+        <!-- Embed in cq.authoring.editor -->

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js.txt
@@ -1,1 +1,2 @@
+#base=js
 shared-component-properties.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
@@ -1,7 +1,26 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 (function ($, ns, channel, window, undefined) {
     function initDialog(type) {
         var dialogSrc = "dialog" + type;
-        var dialogIcon = 'coral-Icon--' + (type == "shared" ? "share" : "globe");
+        var dialogIcon = 'coral-Icon--' + (type === "shared" ? "layersForward" : "globe");
         var dialogTitle = type == "shared" ? "Configure Shared Properties" : "Configure Global Properties";
         return {
             icon: dialogIcon,
@@ -16,7 +35,7 @@
                     var sharedComponentDialogSrc = dialogSrcArray[0].replace("_cq_dialog", dialogSrc) +
                         ".html" + ns.page.info.sharedComponentProperties.root +
                         "/jcr:content/" + type + "-component-properties";
-                    if (type == "shared") {
+                    if (type === "shared") {
                         sharedComponentDialogSrc += "/" + editable.type;
                     }
 
@@ -25,7 +44,7 @@
 
                     ns.edit.actions.doConfigure(editable);
                 } catch (err) {
-                    if (typeof console == "object" && console.error) {
+                    if (typeof console === "object" && console.error) {
                         console.error("Error configuring " + dialogSrc + ": " + err);
                     }
                 } finally {

--- a/content/src/main/content/jcr_root/apps/acs-commons/gui/components/authoring/dialogshared/dialogshared.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/gui/components/authoring/dialogshared/dialogshared.jsp
@@ -1,20 +1,26 @@
-<%@ page import="javax.jcr.Session" %>
-<%@ page import="com.day.cq.commons.jcr.JcrUtil" %>
-<%@page session="false"%>
-<%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling" %>
+<%@ page session="false"
+         import="javax.jcr.Session,
+                 org.apache.jackrabbit.JcrConstants,
+                 com.day.cq.commons.jcr.JcrUtil" %><%
+%><%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling" %><%
 
-<sling:defineObjects />
+%><sling:defineObjects /><%
 
-<%
     String dialogSharedDataPath = slingRequest.getRequestPathInfo().getSuffix();
     Session dialogSharedSession = resourceResolver.adaptTo(Session.class);
 
-    // Ensure the path exists in the JCR so that we don't get a NPE
-    // when attempting to load the dialog.
+    /**
+     * This is an unusual case where we must write a node on a read (GET) to ensure that the the OOTB dialog
+     * implementation does not NPE.
+     *
+     * SharedComponentPropsPageInfoProvider checks if the current user has permissions to write that node, and if not
+     * then flags the shared component properties feature as disabled, which in turn makes it so the UI does not give
+     * the user the buttons to configure shared/global configs (and thus they will not hit this code).
+     **/
+
     if (!dialogSharedSession.nodeExists(dialogSharedDataPath)) {
-        JcrUtil.createPath(dialogSharedDataPath, "nt:unstructured", "nt:unstructured", dialogSharedSession, false);
+        JcrUtil.createPath(dialogSharedDataPath,  JcrConstants.NT_UNSTRUCTURED, JcrConstants.NT_UNSTRUCTURED, dialogSharedSession, false);
         dialogSharedSession.save();
     }
-%>
 
-<%@include file="/libs/cq/gui/components/authoring/dialog/dialog.jsp" %>
+%><%@include file="/libs/cq/gui/components/authoring/dialog/dialog.jsp" %>


### PR DESCRIPTION
@HitmanInWis Hows this look? Mostly some re-org.

Few changes

1) PageRootProvider can take a list of regexes now so this could be used in a multi-tenant situation
2) Simplified the regex; i think its fine simplified - i wrote some tests for it too
3) Updated the shared icon in TouchUI to use one of the "layers" .. agree there arent any great icons; that share icon is so ubiquitous though.
4) Created a SharedComponentProperties service that needs to be satisfied, and then BVP and PageInfo will then be satisfied. (allows PageRootProvider to be used outside of SCP, as you mentioned in the other PR)
5) I gave the classic and touch clientlibs, their own categories so we arent adding them by default to cq.widget and cq.authoring ... we've been having alot of issues with the "on by default" inclusion of authoring JS. To enable this, you just make a new CLthat has `categories=cq.widget `and `embed=acs-commons.shared-component-properties.classic` (or the TouchUI equiv).. iirc you need to make a empty `js.txt` too.

Otherwise its up and running on my local can looks good. If youre OK w the changes I made, merge them into yours, and then ill merge your PR into ACS commons!!!

Thanks again!